### PR TITLE
Allow new seed input

### DIFF
--- a/src/pages/New/New.js
+++ b/src/pages/New/New.js
@@ -87,6 +87,10 @@ export default function New(props) {
     };
   }
 
+  function handleInputChange(event) {
+    set_value(event.target.value);
+  }
+
   if (activeSeedsQuery.loading) {
     return (
       <Container>
@@ -180,7 +184,8 @@ export default function New(props) {
         <Select title="Version" onChange={handleVersion} options={VERSION_CHOICES} selected={version} />
 
         <GroupTitle>Seed</GroupTitle>
-        <input disabled value={value} />
+
+        <input value={value} onChange={handleInputChange} />
 
         <Instructions>
           Clicking <b>Save Seed</b> below will publish this seed to the Home page.


### PR DESCRIPTION
## Problem
Unable to customize seed value on new seed page

## Solution
- Removed `disabled` attribute from `input` element
- Created `handleInputChange` function to `set_value` with new input value

## Demo
<img width="659" alt="Screen Shot 2021-05-15 at 7 05 59 PM" src="https://user-images.githubusercontent.com/69382434/118383195-97c3df80-b5b0-11eb-8d37-81e259bb3f9f.png">
