### PR TITLE
hide add filter button

### DIFF
--- a/src/pages/search/components/ArtifactSearch.js
+++ b/src/pages/search/components/ArtifactSearch.js
@@ -283,7 +283,7 @@ function ArtifactFilters(props) {
 
   const modal_title = <span>Add artefact</span>;
 
-  const modal_trigger = (
+  const modal_trigger = !has_active ? null : (
     <ButtonGroup>
       <Button className="">+&nbsp;{modal_title}</Button>
     </ButtonGroup>


### PR DESCRIPTION
hide "Add filter" button when there' no active filter
<img width="1582" alt="Screenshot 2024-11-18 at 9 14 06 PM" src="https://github.com/user-attachments/assets/fb1cf622-b221-4c25-a6ed-70ff0b463d30">

when there is an active filter, the "Add filter" button should render
<img width="1582" alt="Screenshot 2024-11-18 at 9 14 12 PM" src="https://github.com/user-attachments/assets/ed227233-119f-42f1-8b4d-ce722a97a660">


#### [git stack](https://github.com/magus/git-stack-cli)
- 👉 `1` https://github.com/magus/dcsseeds/pull/6
- ⏳ `2` https://github.com/magus/dcsseeds/pull/7